### PR TITLE
Fixed compilation on Windows.

### DIFF
--- a/shardy/dialect/sdy/transforms/propagation/aggressive_factor_propagation.cc
+++ b/shardy/dialect/sdy/transforms/propagation/aggressive_factor_propagation.cc
@@ -149,8 +149,8 @@ UpdateTensorShardings AggressiveFactorPropagation::propagateFactorShardings(
     ArrayRef<int64_t> factorSizes, MeshAttr mesh, Operation* op,
     bool conservativePropagation) const {
   UpdateTensorShardings result{
-      .updateOperands = BitVector(projection.getNumOperands()),
-      .updateResults = BitVector(projection.getNumResults())};
+      /* .updateOperands = */ BitVector(projection.getNumOperands()),
+      /* .updateResults = */ BitVector(projection.getNumResults())};
 
   // We get the compatible major sharding axes for all factors.
   AxesPerFactor axesPerFactor = getCompatibleMajorShardingAxesForAllFactors(

--- a/shardy/dialect/sdy/transforms/propagation/basic_factor_propagation.cc
+++ b/shardy/dialect/sdy/transforms/propagation/basic_factor_propagation.cc
@@ -409,8 +409,8 @@ UpdateTensorShardings BasicFactorPropagation::propagateFactorShardings(
     ArrayRef<int64_t> factorSizes, MeshAttr mesh, Operation* op,
     bool conservativePropagation) const {
   UpdateTensorShardings result{
-      .updateOperands = BitVector(projection.getNumOperands()),
-      .updateResults = BitVector(projection.getNumResults())};
+      /* .updateOperands = */ BitVector(projection.getNumOperands()),
+      /* .updateResults = */ BitVector(projection.getNumResults())};
 
   // We propagate each factor separately.
   for (auto [factorIndex, factorSize] : llvm::enumerate(factorSizes)) {

--- a/shardy/dialect/sdy/transforms/propagation/basic_propagation.cc
+++ b/shardy/dialect/sdy/transforms/propagation/basic_propagation.cc
@@ -612,8 +612,8 @@ LogicalResult BasicPropagationPassImpl::propagate(
   // convergence), since we make sure ops whose sharding changes are
   // added back to the worklist.
   GreedyRewriteConfig config{
-      .useTopDownTraversal = true,
-      .enableRegionSimplification = mlir::GreedySimplifyRegionLevel::Disabled};
+      /* .useTopDownTraversal = */ true,
+      /* .enableRegionSimplification = */ mlir::GreedySimplifyRegionLevel::Disabled};
   if (failed(applyPatternsAndFoldGreedily(moduleOp, std::move(patterns),
                                           config))) {
     return failure();

--- a/shardy/dialect/sdy/transforms/propagation/sharding_projection.cc
+++ b/shardy/dialect/sdy/transforms/propagation/sharding_projection.cc
@@ -146,8 +146,8 @@ TensorShardingAttr TensorFactorShardings::createTensorShardingAttr(
 
 UpdateShardings ShardingProjection::updateSharding(
     int64_t factorIndex, ArrayRef<AxisRefAttr> newAxes) {
-  UpdateShardings result{.updateOperands = BitVector(getNumOperands()),
-                         .updateResults = BitVector(getNumResults())};
+  UpdateShardings result{/* .updateOperands = */ BitVector(getNumOperands()),
+                         /* .updateResults = */ BitVector(getNumResults())};
   for (auto [i, tensor] : llvm::enumerate(operands)) {
     result.updateOperands[i] = tensor.updateShardingAxes(factorIndex, newAxes);
   }
@@ -180,8 +180,8 @@ std::optional<AxisRefInfo> getAxisRefInfo(ArrayRef<AxisRefAttr> axes,
   AxisRefAttr axisRef = axes[axisIndex];
   SubAxisInfoAttr splitInfo = axisRef.getSubAxisInfo();
   return AxisRefInfo{
-      .size = axisRef.getSize(mesh),
-      .splitPreSize = splitInfo ? std::make_optional(splitInfo.getPreSize())
+      /* .size = */ axisRef.getSize(mesh),
+      /* .splitPreSize = */ splitInfo ? std::make_optional(splitInfo.getPreSize())
                                 : std::nullopt};
 }
 


### PR DESCRIPTION
I'm currently attempting to get XLA to compile on Windows with CUDA support and this PR fixes one of the issues I ran into related to the shardy dependency. The tl;dr is that designated initializers are a C++ 20 feature that GCC supports even when you're compiling using C++ 17 (which XLA does), but unfortunately MSVC is stricter and does not support it for that version of C++. This PR removes the uses of that feature from shardy.