### PR TITLE
Add missing docstrings to dialect documentation

### DIFF
--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -75,7 +75,7 @@ def Sdy_Mesh : AttrDef<Sdy_Dialect, "Mesh"> {
       ordering: <["a"=3, "b"=2], device_ids=[0, 2, 4, 1, 3, 5]>
   }];
   let parameters = (ins
-      OptionalArrayRefParameter<"MeshAxisAttr", "Mesh axes">:$axes,
+      OptionalArrayRefParameter<"MeshAxisAttr", "mesh axes">:$axes,
       OptionalArrayRefParameter<"int64_t", "explicit device ordering or maximal device id">: $device_ids
   );
 
@@ -177,7 +177,7 @@ def Sdy_AxisRef : AttrDef<Sdy_Dialect, "AxisRef"> {
   let mnemonic = "axis_ref";
   let summary = "Reference to either a full axis or a split sub-axis";
   let parameters = (ins
-      StringRefParameter<"name", "the name of this axis">:$name,
+      StringRefParameter<"the name of the axis">:$name,
       OptionalParameter<"SubAxisInfoAttr", "additional info if this is a sub axis">:$sub_axis_info
   );
   let assemblyFormat = "`` $name (`` `:` `` $sub_axis_info^)?";

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -42,7 +42,7 @@ def Sdy_MeshAxis : AttrDef<Sdy_Dialect, "MeshAxis"> {
   let summary = "Named axis in a mesh";
   let parameters = (ins
       StringRefParameter<"name">:$name,
-      AttrOrTypeParameter<"int64_t", "size">:$size
+      AttrOrTypeParameter<"int64_t", "Size of this axis">:$size
   );
   let assemblyFormat = "`` $name `` `=` `` $size";
   let genVerifyDecl = 1;
@@ -79,8 +79,8 @@ def Sdy_Mesh : AttrDef<Sdy_Dialect, "Mesh"> {
       ordering: <["a"=3, "b"=2], device_ids=[0, 2, 4, 1, 3, 5]>
   }];
   let parameters = (ins
-      OptionalArrayRefParameter<"MeshAxisAttr", "axes">:$axes,
-      OptionalArrayRefParameter<"int64_t", "explicit device ordering">: $device_ids
+      OptionalArrayRefParameter<"MeshAxisAttr", "List of mesh axes">:$axes,
+      OptionalArrayRefParameter<"int64_t", "explicit device ordering or maximal device id">: $device_ids
   );
 
   let assemblyFormat = [{
@@ -155,8 +155,8 @@ def Sdy_SubAxisInfo : AttrDef<Sdy_Dialect, "SubAxisInfo"> {
     denoted as follows: `(m)k` for pre-size m and size k.
   }];
   let parameters = (ins
-      AttrOrTypeParameter<"int64_t", "The product of axis sizes to the left of the sub-axis">:$pre_size,
-      AttrOrTypeParameter<"int64_t", "sub-axis size">:$size
+      AttrOrTypeParameter<"int64_t", "The product of axis sizes to the left of this sub-axis">:$pre_size,
+      AttrOrTypeParameter<"int64_t", "Size of this sub-axis">:$size
   );
   let assemblyFormat = "`(` $pre_size `)` `` $size";
 
@@ -181,8 +181,8 @@ def Sdy_AxisRef : AttrDef<Sdy_Dialect, "AxisRef"> {
   let mnemonic = "axis_ref";
   let summary = "Reference to either a full axis or a split sub-axis";
   let parameters = (ins
-      StringRefParameter<"name">:$name,
-      OptionalParameter<"SubAxisInfoAttr", "sub axis info">:$sub_axis_info
+      StringRefParameter<"name", "The name of the axis">:$name,
+      OptionalParameter<"SubAxisInfoAttr", "Additional info if this is a sub axis">:$sub_axis_info
   );
   let assemblyFormat = "`` $name (`` `:` `` $sub_axis_info^)?";
 
@@ -631,7 +631,7 @@ def Sdy_TensorShardingPerValue : AttrDef<Sdy_Dialect, "TensorShardingPerValue"> 
   let mnemonic = "sharding_per_value";
   let summary = "Tensor sharding per operand/result of an op";
   let parameters = (ins
-      OptionalArrayRefParameter<"TensorShardingAttr", "shardings">:$shardings
+      OptionalArrayRefParameter<"TensorShardingAttr", "Shardings per value">:$shardings
   );
   let assemblyFormat = "`<` `[` (`]`):($shardings^ `]`)? `>`";
 
@@ -681,7 +681,7 @@ def Sdy_DimMapping : AttrDef<Sdy_Dialect, "DimMapping"> {
     i.e. the dimension isn't mapped to any factors.
    }];
   let parameters = (ins
-    OptionalArrayRefParameter<"int64_t", "list of factor indices">:$factor_indices
+    OptionalArrayRefParameter<"int64_t", "Factors this dimension is mapped to">:$factor_indices
   );
 
   let hasCustomAssemblyFormat = 1;
@@ -750,7 +750,7 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
   }];
 
   let parameters = (ins
-      OptionalArrayRefParameter<"int64_t", "factor sizes">:$factor_sizes,
+      OptionalArrayRefParameter<"int64_t", "Sizes of all factors in this rule">:$factor_sizes,
       OptionalArrayRefParameter<"TensorMappingAttr", "operand mappings">:$operand_mappings,
       OptionalArrayRefParameter<"TensorMappingAttr", "result mappings">:$result_mappings,
       OptionalArrayRefParameter<"int64_t">:$reduction_factors,

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -790,7 +790,7 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
 def Sdy_AxisRefList : ArrayOfAttr<Sdy_Dialect, "AxisRefList",
                                  "axis_ref_list", "AxisRefAttr"> {
   let assemblyFormat = "`{` (`}`) : ($value^ `` `}`)?";
-  let summary = "List of axis refs"
+  let summary = "List of axis refs";
   let parameters = (ins
       OptionalArrayRefParameter<"AxisRefAttr", "axis refs">:$value
   );

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -29,6 +29,8 @@ include "shardy/dialect/sdy/ir/dialect.td"
 // split.
 def Sdy_ManualAxes : ArrayOfAttr<Sdy_Dialect, "ManualAxes",
                                  "manual_axes", "StringAttr"> {
+  let mnemonic = "manual_axes";
+  let summary = "Manual axes definition PLACEHOLDER";
   let assemblyFormat = "`{` (`}`) : ($value^ `` `}`)?";
 }
 
@@ -133,6 +135,8 @@ def Sdy_Mesh : AttrDef<Sdy_Dialect, "Mesh"> {
   }];
 }
 
+def Sdy_SubAxisInfoP : OptionalParameter<"SubAxisInfoAttr", "sub axis info PLACEHOLDER">;
+
 def Sdy_SubAxisInfo : AttrDef<Sdy_Dialect, "SubAxisInfo"> {
   let mnemonic = "sub_axis_info";
   let summary = "Info about how this sub-axis is derived from the full axis";
@@ -171,7 +175,7 @@ def Sdy_AxisRef : AttrDef<Sdy_Dialect, "AxisRef"> {
   let summary = "Reference to either a full axis or a split sub-axis";
   let parameters = (ins
       StringRefParameter<"name">:$name,
-      OptionalParameter<"SubAxisInfoAttr">:$sub_axis_info
+      Sdy_SubAxisInfoP:$sub_axis_info
   );
   let assemblyFormat = "`` $name (`` `:` `` $sub_axis_info^)?";
 
@@ -698,6 +702,7 @@ def Sdy_TensorMapping : AttrDef<Sdy_Dialect, "TensorMapping"> {
   }];
 }
 
+def Sdy_TensorMappings : OptionalArrayRefParameter<"TensorMappingAttr", "list of tensor mappings PLACEHOLDER">;
 
 def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
   let mnemonic = "op_sharding_rule";
@@ -736,8 +741,8 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
 
   let parameters = (ins
       OptionalArrayRefParameter<"int64_t">:$factor_sizes,
-      OptionalArrayRefParameter<"TensorMappingAttr">:$operand_mappings,
-      OptionalArrayRefParameter<"TensorMappingAttr">:$result_mappings,
+      Sdy_TensorMappings:$operand_mappings,
+      Sdy_TensorMappings:$result_mappings,
       DefaultValuedParameter<"bool", "false">:$is_custom_rule
   );
 

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -177,7 +177,7 @@ def Sdy_AxisRef : AttrDef<Sdy_Dialect, "AxisRef"> {
   let mnemonic = "axis_ref";
   let summary = "Reference to either a full axis or a split sub-axis";
   let parameters = (ins
-      StringRefParameter<"the name of the axis">:$name,
+      StringRefParameter<"the name of this axis">:$name,
       OptionalParameter<"SubAxisInfoAttr", "additional info if this is a sub axis">:$sub_axis_info
   );
   let assemblyFormat = "`` $name (`` `:` `` $sub_axis_info^)?";
@@ -751,7 +751,8 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
       OptionalArrayRefParameter<"TensorMappingAttr", "result mappings">:$result_mappings,
       OptionalArrayRefParameter<"int64_t", "indices of factors requiring reduction">:$reduction_factors,
       OptionalArrayRefParameter<"int64_t", "indices of factors requiring full replication">:$need_replication_factors,
-      DefaultValuedParameter<"bool", "false", "whether the rule is for a stablehlo.custom_call">:$is_custom_rule
+      DefaultValuedParameter<"bool", "false",
+                             "whether the rule is for a stablehlo.custom_call">:$is_custom_rule
   );
 
   let assemblyFormat = [{

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -356,8 +356,8 @@ def Sdy_DimensionSharding : AttrDef<Sdy_Dialect, "DimensionSharding"> {
 
   let parameters = (ins
     Sdy_AxisRefs:$axes,
-    AttrOrTypeParameter<"bool", "whether the dimension is closed">:$is_closed,
-    OptionalParameter<"std::optional<int64_t>", "priority of dimension sharding">:$priority
+    AttrOrTypeParameter<"bool", "If false, this dimension can be further sharded">:$is_closed,
+    OptionalParameter<"std::optional<int64_t>", "the priority used during user priority based propagation">:$priority
   );
 
   let builders = [

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -32,7 +32,7 @@ def Sdy_ManualAxes : ArrayOfAttr<Sdy_Dialect, "ManualAxes",
   let mnemonic = "manual_axes";
   let summary = "A list of axes that a ManualComputationOp is manual on";
   let parameters = (ins
-      ArrayRefParameter<"StringAttr", "value">:$value
+      OptionalArrayRefParameter<"StringAttr", "value">:$value
   );
   let assemblyFormat = "`{` (`}`) : ($value^ `` `}`)?";
 }
@@ -790,18 +790,18 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
 def Sdy_AxisRefList : ArrayOfAttr<Sdy_Dialect, "AxisRefList",
                                  "axis_ref_list", "AxisRefAttr"> {
   let assemblyFormat = "`{` (`}`) : ($value^ `` `}`)?";
-  let summary = "List of axis refs";
+  let summary = "List of axis refs"
   let parameters = (ins
-      ArrayRefParameter<"AxisRefAttr", "axis refs">:$value
+      OptionalArrayRefParameter<"AxisRefAttr", "axis refs">:$value
   );
 }
 
 def Sdy_ListOfAxisRefLists : ArrayOfAttr<Sdy_Dialect, "ListOfAxisRefLists",
                                  "list_of_axis_ref_lists", "AxisRefListAttr"> {
-    let summary = "List of axis ref lists";
-    let parameters = (ins
-        ArrayRefParameter<"AxisRefListAttr", "axis ref lists">:$value
-    );
+  let summary = "List of axis ref lists";
+  let parameters = (ins
+      OptionalArrayRefParameter<"AxisRefListAttr", "axis ref lists">:$value
+  );
 }
 
 def Sdy_EmptyAxesPerDim : AttrConstraint<

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -149,8 +149,8 @@ def Sdy_SubAxisInfo : AttrDef<Sdy_Dialect, "SubAxisInfo"> {
     denoted as follows: `(m)k` for pre-size m and size k.
   }];
   let parameters = (ins
-      AttrOrTypeParameter<"int64_t", "pre-size">:$pre_size,
-      AttrOrTypeParameter<"int64_t", "size">:$size
+      AttrOrTypeParameter<"int64_t", "The product of axis sizes to the left of the sub-axis">:$pre_size,
+      AttrOrTypeParameter<"int64_t", "sub-axis size">:$size
   );
   let assemblyFormat = "`(` $pre_size `)` `` $size";
 
@@ -350,8 +350,8 @@ def Sdy_DimensionSharding : AttrDef<Sdy_Dialect, "DimensionSharding"> {
 
   let parameters = (ins
     Sdy_AxisRefs:$axes,
-    AttrOrTypeParameter<"bool", "whether this dimension is closed">:$is_closed,
-    OptionalParameter<"std::optional<int64_t>", "priority of this dimension sharding">:$priority
+    AttrOrTypeParameter<"bool", "whether the dimension is closed">:$is_closed,
+    OptionalParameter<"std::optional<int64_t>", "priority of dimension sharding">:$priority
   );
 
   let builders = [
@@ -429,7 +429,7 @@ def Sdy_TensorSharding : AttrDef<Sdy_Dialect, "TensorSharding"> {
   }];
   let parameters = (ins
       Sdy_MeshOrRef:$mesh_or_ref,
-      OptionalArrayRefParameter<"DimensionShardingAttr", "dimension sharding">:$dim_shardings,
+      OptionalArrayRefParameter<"DimensionShardingAttr", "dimension shardings">:$dim_shardings,
       Sdy_AxisRefs:$replicated_axes
   );
   let assemblyFormat = [{
@@ -693,7 +693,7 @@ def Sdy_TensorMapping : AttrDef<Sdy_Dialect, "TensorMapping"> {
   let mnemonic = "tensor_mapping";
   let summary = "Factor mappings for each dimension of a tensor.";
   let parameters = (ins
-      OptionalArrayRefParameter<"DimMappingAttr", "dimension mapping">:$dim_mappings
+      OptionalArrayRefParameter<"DimMappingAttr", "dimension mappings">:$dim_mappings
   );
 
   let assemblyFormat = "`` `[` (`]`):($dim_mappings^ `]`)? ``";
@@ -742,7 +742,7 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
       OptionalArrayRefParameter<"int64_t", "factor sizes">:$factor_sizes,
       OptionalArrayRefParameter<"TensorMappingAttr", "operand mappings">:$operand_mappings,
       OptionalArrayRefParameter<"TensorMappingAttr", "result mappings">:$result_mappings,
-      DefaultValuedParameter<"bool", "false", "whether this is a stablehlo.custom_call">:$is_custom_rule
+      DefaultValuedParameter<"bool", "false", "whether the rule is for a stablehlo.custom_call">:$is_custom_rule
   );
 
   let assemblyFormat = [{

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -38,7 +38,7 @@ def Sdy_MeshAxis : AttrDef<Sdy_Dialect, "MeshAxis"> {
   let summary = "Named axis in a mesh";
   let parameters = (ins
       StringRefParameter<"name">:$name,
-      AttrOrTypeParameter<"int64_t", "Size of this axis">:$size
+      AttrOrTypeParameter<"int64_t", "size of this axis">:$size
   );
   let assemblyFormat = "`` $name `` `=` `` $size";
   let genVerifyDecl = 1;
@@ -75,7 +75,7 @@ def Sdy_Mesh : AttrDef<Sdy_Dialect, "Mesh"> {
       ordering: <["a"=3, "b"=2], device_ids=[0, 2, 4, 1, 3, 5]>
   }];
   let parameters = (ins
-      OptionalArrayRefParameter<"MeshAxisAttr", "List of mesh axes">:$axes,
+      OptionalArrayRefParameter<"MeshAxisAttr", "Mesh axes">:$axes,
       OptionalArrayRefParameter<"int64_t", "explicit device ordering or maximal device id">: $device_ids
   );
 
@@ -151,8 +151,8 @@ def Sdy_SubAxisInfo : AttrDef<Sdy_Dialect, "SubAxisInfo"> {
     denoted as follows: `(m)k` for pre-size m and size k.
   }];
   let parameters = (ins
-      AttrOrTypeParameter<"int64_t", "The product of axis sizes to the left of this sub-axis">:$pre_size,
-      AttrOrTypeParameter<"int64_t", "Size of this sub-axis">:$size
+      AttrOrTypeParameter<"int64_t", "the product of axis sizes to the left of this sub-axis">:$pre_size,
+      AttrOrTypeParameter<"int64_t", "size of this sub-axis">:$size
   );
   let assemblyFormat = "`(` $pre_size `)` `` $size";
 
@@ -177,8 +177,8 @@ def Sdy_AxisRef : AttrDef<Sdy_Dialect, "AxisRef"> {
   let mnemonic = "axis_ref";
   let summary = "Reference to either a full axis or a split sub-axis";
   let parameters = (ins
-      StringRefParameter<"name", "The name of the axis">:$name,
-      OptionalParameter<"SubAxisInfoAttr", "Additional info if this is a sub axis">:$sub_axis_info
+      StringRefParameter<"name", "the name of this axis">:$name,
+      OptionalParameter<"SubAxisInfoAttr", "additional info if this is a sub axis">:$sub_axis_info
   );
   let assemblyFormat = "`` $name (`` `:` `` $sub_axis_info^)?";
 
@@ -336,7 +336,7 @@ def Sdy_AxisRef : AttrDef<Sdy_Dialect, "AxisRef"> {
   }];
 }
 
-def Sdy_AxisRefs : OptionalArrayRefParameter<"AxisRefAttr", "list of axis refs">;
+def Sdy_AxisRefs : OptionalArrayRefParameter<"AxisRefAttr", "axis refs">;
 
 def Sdy_DimensionSharding : AttrDef<Sdy_Dialect, "DimensionSharding"> {
   let mnemonic = "dimension_sharding";
@@ -352,7 +352,7 @@ def Sdy_DimensionSharding : AttrDef<Sdy_Dialect, "DimensionSharding"> {
 
   let parameters = (ins
     Sdy_AxisRefs:$axes,
-    AttrOrTypeParameter<"bool", "If false, this dimension can be further sharded">:$is_closed,
+    AttrOrTypeParameter<"bool", "if false, this dimension can be further sharded">:$is_closed,
     OptionalParameter<"std::optional<int64_t>", "the priority used during user priority based propagation">:$priority
   );
 
@@ -627,7 +627,7 @@ def Sdy_TensorShardingPerValue : AttrDef<Sdy_Dialect, "TensorShardingPerValue"> 
   let mnemonic = "sharding_per_value";
   let summary = "Tensor sharding per operand/result of an op";
   let parameters = (ins
-      OptionalArrayRefParameter<"TensorShardingAttr", "Shardings per value">:$shardings
+      OptionalArrayRefParameter<"TensorShardingAttr", "shardings per value">:$shardings
   );
   let assemblyFormat = "`<` `[` (`]`):($shardings^ `]`)? `>`";
 
@@ -677,7 +677,7 @@ def Sdy_DimMapping : AttrDef<Sdy_Dialect, "DimMapping"> {
     i.e. the dimension isn't mapped to any factors.
    }];
   let parameters = (ins
-    OptionalArrayRefParameter<"int64_t", "Factors this dimension is mapped to">:$factor_indices
+    OptionalArrayRefParameter<"int64_t", "factors this dimension is mapped to">:$factor_indices
   );
 
   let hasCustomAssemblyFormat = 1;
@@ -746,12 +746,12 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
   }];
 
   let parameters = (ins
-      OptionalArrayRefParameter<"int64_t", "Sizes of all factors in this rule">:$factor_sizes,
+      OptionalArrayRefParameter<"int64_t", "sizes of all factors in this rule">:$factor_sizes,
       OptionalArrayRefParameter<"TensorMappingAttr", "operand mappings">:$operand_mappings,
       OptionalArrayRefParameter<"TensorMappingAttr", "result mappings">:$result_mappings,
-      OptionalArrayRefParameter<"int64_t">:$reduction_factors,
-      OptionalArrayRefParameter<"int64_t">:$need_replication_factors,
-      DefaultValuedParameter<"bool", "false", "whether the rule is for a stablehlo.custom_call>:$is_custom_rule
+      OptionalArrayRefParameter<"int64_t", "indices of factors requiring reduction">:$reduction_factors,
+      OptionalArrayRefParameter<"int64_t", "indices of factors requiring full replication">:$need_replication_factors,
+      DefaultValuedParameter<"bool", "false", "whether the rule is for a stablehlo.custom_call">:$is_custom_rule
   );
 
   let assemblyFormat = [{
@@ -805,17 +805,11 @@ def Sdy_AxisRefList : ArrayOfAttr<Sdy_Dialect, "AxisRefList",
                                  "axis_ref_list", "AxisRefAttr"> {
   let assemblyFormat = "`{` (`}`) : ($value^ `` `}`)?";
   let summary = "List of axis refs";
-  let parameters = (ins
-      OptionalArrayRefParameter<"AxisRefAttr", "axis refs">:$value
-  );
 }
 
 def Sdy_ListOfAxisRefLists : ArrayOfAttr<Sdy_Dialect, "ListOfAxisRefLists",
                                  "list_of_axis_ref_lists", "AxisRefListAttr"> {
   let summary = "List of axis ref lists";
-  let parameters = (ins
-      OptionalArrayRefParameter<"AxisRefListAttr", "axis ref lists">:$value
-  );
 }
 
 def Sdy_EmptyAxesPerDim : AttrConstraint<

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -29,11 +29,7 @@ include "shardy/dialect/sdy/ir/dialect.td"
 // split.
 def Sdy_ManualAxes : ArrayOfAttr<Sdy_Dialect, "ManualAxes",
                                  "manual_axes", "StringAttr"> {
-  let mnemonic = "manual_axes";
   let summary = "A list of axes that a ManualComputationOp is manual on";
-  let parameters = (ins
-      OptionalArrayRefParameter<"StringAttr", "value">:$value
-  );
   let assemblyFormat = "`{` (`}`) : ($value^ `` `}`)?";
 }
 

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -76,7 +76,8 @@ def Sdy_Mesh : AttrDef<Sdy_Dialect, "Mesh"> {
   }];
   let parameters = (ins
       OptionalArrayRefParameter<"MeshAxisAttr", "mesh axes">:$axes,
-      OptionalArrayRefParameter<"int64_t", "explicit device ordering or maximal device id">: $device_ids
+      OptionalArrayRefParameter<"int64_t",
+                                "explicit device ordering or maximal device id">:$device_ids
   );
 
   let assemblyFormat = [{
@@ -151,7 +152,8 @@ def Sdy_SubAxisInfo : AttrDef<Sdy_Dialect, "SubAxisInfo"> {
     denoted as follows: `(m)k` for pre-size m and size k.
   }];
   let parameters = (ins
-      AttrOrTypeParameter<"int64_t", "the product of axis sizes to the left of this sub-axis">:$pre_size,
+      AttrOrTypeParameter<"int64_t",
+                          "the product of sub-axis sizes to the left of this sub-axis">:$pre_size,
       AttrOrTypeParameter<"int64_t", "size of this sub-axis">:$size
   );
   let assemblyFormat = "`(` $pre_size `)` `` $size";
@@ -353,7 +355,8 @@ def Sdy_DimensionSharding : AttrDef<Sdy_Dialect, "DimensionSharding"> {
   let parameters = (ins
     Sdy_AxisRefs:$axes,
     AttrOrTypeParameter<"bool", "if false, this dimension can be further sharded">:$is_closed,
-    OptionalParameter<"std::optional<int64_t>", "the priority used during user priority based propagation">:$priority
+    OptionalParameter<"std::optional<int64_t>",
+                      "the priority used during user priority based propagation">:$priority
   );
 
   let builders = [

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -30,7 +30,10 @@ include "shardy/dialect/sdy/ir/dialect.td"
 def Sdy_ManualAxes : ArrayOfAttr<Sdy_Dialect, "ManualAxes",
                                  "manual_axes", "StringAttr"> {
   let mnemonic = "manual_axes";
-  let summary = "Manual axes definition PLACEHOLDER";
+  let summary = "A list of axes that a ManualComputationOp is manual on";
+  let parameters = (ins
+      ArrayRefParameter<"StringAttr", "value">:$value
+  );
   let assemblyFormat = "`{` (`}`) : ($value^ `` `}`)?";
 }
 
@@ -39,7 +42,7 @@ def Sdy_MeshAxis : AttrDef<Sdy_Dialect, "MeshAxis"> {
   let summary = "Named axis in a mesh";
   let parameters = (ins
       StringRefParameter<"name">:$name,
-      "int64_t":$size
+      AttrOrTypeParameter<"int64_t", "size">:$size
   );
   let assemblyFormat = "`` $name `` `=` `` $size";
   let genVerifyDecl = 1;
@@ -76,8 +79,8 @@ def Sdy_Mesh : AttrDef<Sdy_Dialect, "Mesh"> {
       ordering: <["a"=3, "b"=2], device_ids=[0, 2, 4, 1, 3, 5]>
   }];
   let parameters = (ins
-      OptionalArrayRefParameter<"MeshAxisAttr">:$axes,
-      OptionalArrayRefParameter<"int64_t">: $device_ids
+      OptionalArrayRefParameter<"MeshAxisAttr", "axes">:$axes,
+      OptionalArrayRefParameter<"int64_t", "explicit device ordering">: $device_ids
   );
 
   let assemblyFormat = [{
@@ -135,8 +138,6 @@ def Sdy_Mesh : AttrDef<Sdy_Dialect, "Mesh"> {
   }];
 }
 
-def Sdy_SubAxisInfoP : OptionalParameter<"SubAxisInfoAttr", "sub axis info PLACEHOLDER">;
-
 def Sdy_SubAxisInfo : AttrDef<Sdy_Dialect, "SubAxisInfo"> {
   let mnemonic = "sub_axis_info";
   let summary = "Info about how this sub-axis is derived from the full axis";
@@ -148,8 +149,8 @@ def Sdy_SubAxisInfo : AttrDef<Sdy_Dialect, "SubAxisInfo"> {
     denoted as follows: `(m)k` for pre-size m and size k.
   }];
   let parameters = (ins
-      "int64_t":$pre_size,
-      "int64_t":$size
+      AttrOrTypeParameter<"int64_t", "pre-size">:$pre_size,
+      AttrOrTypeParameter<"int64_t", "size">:$size
   );
   let assemblyFormat = "`(` $pre_size `)` `` $size";
 
@@ -175,7 +176,7 @@ def Sdy_AxisRef : AttrDef<Sdy_Dialect, "AxisRef"> {
   let summary = "Reference to either a full axis or a split sub-axis";
   let parameters = (ins
       StringRefParameter<"name">:$name,
-      Sdy_SubAxisInfoP:$sub_axis_info
+      OptionalParameter<"SubAxisInfoAttr", "sub axis info">:$sub_axis_info
   );
   let assemblyFormat = "`` $name (`` `:` `` $sub_axis_info^)?";
 
@@ -349,8 +350,8 @@ def Sdy_DimensionSharding : AttrDef<Sdy_Dialect, "DimensionSharding"> {
 
   let parameters = (ins
     Sdy_AxisRefs:$axes,
-    "bool":$is_closed,
-    OptionalParameter<"std::optional<int64_t>">:$priority
+    AttrOrTypeParameter<"bool", "whether this dimension is closed">:$is_closed,
+    OptionalParameter<"std::optional<int64_t>", "priority of this dimension sharding">:$priority
   );
 
   let builders = [
@@ -428,7 +429,7 @@ def Sdy_TensorSharding : AttrDef<Sdy_Dialect, "TensorSharding"> {
   }];
   let parameters = (ins
       Sdy_MeshOrRef:$mesh_or_ref,
-      OptionalArrayRefParameter<"DimensionShardingAttr">:$dim_shardings,
+      OptionalArrayRefParameter<"DimensionShardingAttr", "dimension sharding">:$dim_shardings,
       Sdy_AxisRefs:$replicated_axes
   );
   let assemblyFormat = [{
@@ -624,7 +625,7 @@ def Sdy_TensorShardingPerValue : AttrDef<Sdy_Dialect, "TensorShardingPerValue"> 
   let mnemonic = "sharding_per_value";
   let summary = "Tensor sharding per operand/result of an op";
   let parameters = (ins
-      OptionalArrayRefParameter<"TensorShardingAttr">:$shardings
+      OptionalArrayRefParameter<"TensorShardingAttr", "shardings">:$shardings
   );
   let assemblyFormat = "`<` `[` (`]`):($shardings^ `]`)? `>`";
 
@@ -674,7 +675,7 @@ def Sdy_DimMapping : AttrDef<Sdy_Dialect, "DimMapping"> {
     i.e. the dimension isn't mapped to any factors.
    }];
   let parameters = (ins
-    OptionalArrayRefParameter<"int64_t">:$factor_indices
+    OptionalArrayRefParameter<"int64_t", "list of factor indices">:$factor_indices
   );
 
   let hasCustomAssemblyFormat = 1;
@@ -692,7 +693,7 @@ def Sdy_TensorMapping : AttrDef<Sdy_Dialect, "TensorMapping"> {
   let mnemonic = "tensor_mapping";
   let summary = "Factor mappings for each dimension of a tensor.";
   let parameters = (ins
-      OptionalArrayRefParameter<"DimMappingAttr">:$dim_mappings
+      OptionalArrayRefParameter<"DimMappingAttr", "dimension mapping">:$dim_mappings
   );
 
   let assemblyFormat = "`` `[` (`]`):($dim_mappings^ `]`)? ``";
@@ -701,8 +702,6 @@ def Sdy_TensorMapping : AttrDef<Sdy_Dialect, "TensorMapping"> {
     int64_t getRank() const { return getDimMappings().size(); }
   }];
 }
-
-def Sdy_TensorMappings : OptionalArrayRefParameter<"TensorMappingAttr", "list of tensor mappings PLACEHOLDER">;
 
 def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
   let mnemonic = "op_sharding_rule";
@@ -740,10 +739,10 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
   }];
 
   let parameters = (ins
-      OptionalArrayRefParameter<"int64_t">:$factor_sizes,
-      Sdy_TensorMappings:$operand_mappings,
-      Sdy_TensorMappings:$result_mappings,
-      DefaultValuedParameter<"bool", "false">:$is_custom_rule
+      OptionalArrayRefParameter<"int64_t", "factor sizes">:$factor_sizes,
+      OptionalArrayRefParameter<"TensorMappingAttr", "operand mappings">:$operand_mappings,
+      OptionalArrayRefParameter<"TensorMappingAttr", "result mappings">:$result_mappings,
+      DefaultValuedParameter<"bool", "false", "whether this is a stablehlo.custom_call">:$is_custom_rule
   );
 
   let assemblyFormat = [{
@@ -791,10 +790,18 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
 def Sdy_AxisRefList : ArrayOfAttr<Sdy_Dialect, "AxisRefList",
                                  "axis_ref_list", "AxisRefAttr"> {
   let assemblyFormat = "`{` (`}`) : ($value^ `` `}`)?";
+  let summary = "List of axis refs";
+  let parameters = (ins
+      ArrayRefParameter<"AxisRefAttr", "axis refs">:$value
+  );
 }
 
 def Sdy_ListOfAxisRefLists : ArrayOfAttr<Sdy_Dialect, "ListOfAxisRefLists",
                                  "list_of_axis_ref_lists", "AxisRefListAttr"> {
+    let summary = "List of axis ref lists";
+    let parameters = (ins
+        ArrayRefParameter<"AxisRefListAttr", "axis ref lists">:$value
+    );
 }
 
 def Sdy_EmptyAxesPerDim : AttrConstraint<


### PR DESCRIPTION
Some of the descriptions I added are not very descriptive. If you have suggestions, please let me know.