### PR TITLE
Add constraints to attrs.td and ops.td

### DIFF
--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -76,8 +76,11 @@ def Sdy_Mesh : AttrDef<Sdy_Dialect, "Mesh"> {
 
     **Constraints:**
     - Elements in `axes` must not have duplicate names.
-    - The product of axis sizes must match the number of devices.
-    - If `device_ids` is specified, all of its elements must be non-negative.
+    - If `device_ids` is specified:
+      - The product of axis sizes must match the number of devices.
+      - All of its elements must be non-negative.
+      - `device_ids` should not be equal to `iota(product(axis_sizes))`.
+      - Sorted `device_ids` must be `iota(product(axis_sizes))`.
   }];
   let parameters = (ins
       OptionalArrayRefParameter<"MeshAxisAttr", "mesh axes">:$axes,
@@ -464,7 +467,7 @@ def Sdy_TensorSharding : AttrDef<Sdy_Dialect, "TensorSharding"> {
     - The tensor should have a rank.
     - The number of dimension shardings is equal to the rank of the tensor.
     - Dimensions of size 0 aren't sharded.
-    - Replicated axes are ordered w.r.t. `mesh_or_ref` (see `AxisRefAttr::getMeshComparator`).
+    - Items in `replicated_axes` are ordered w.r.t. `mesh_or_ref` (see `AxisRefAttr::getMeshComparator`).
   }];
   let parameters = (ins
       Sdy_MeshOrRef:$mesh_or_ref,
@@ -792,8 +795,6 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
     for `stablehlo.custom_call` ops.
 
     **Constraints:**
-    - Elements in `reduction_factors` and `need_replication_factors` must
-      satisfy the constraints of `DimMappingAttr`.
     - Number of operand/result mappings must match the number of
       operands/results of the op.
     - There is at least one mapping (can't have a rule for an op with no
@@ -801,6 +802,11 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
     - Rank of each `TensorMappingAttr` matches the rank of the corresponding
       tensor type.
     - No duplicate factor indices in each `TensorMappingAttr`.
+    - Elements in `reduction_factors` and `need_replication_factors` must
+      be in range [0, `$factor_sizes`].
+    - No duplicate factor indices in each of `reduction_factors` or
+      `need_replication_factors`, and no duplicate factor indices across both
+      `reduction_factors` and `need_replication_factors`.
   }];
 
   let parameters = (ins
@@ -867,7 +873,7 @@ def Sdy_AxisRefList : ArrayOfAttr<Sdy_Dialect, "AxisRefList",
   let description = [{
     **Constraints:**
     - Elements in `value` must satisfy the constraints of `AxisRefAttr`.
-    - There are no duplicate axis-refs.
+    - There are no duplicate axis-refs or sub-axes that overlap with one another.
     - No two adjacent axis-refs are consecutive sub-axes of that same full axis,
       i.e., they can be merged into one sub-axis or the full axis.
   }];

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -77,10 +77,10 @@ def Sdy_Mesh : AttrDef<Sdy_Dialect, "Mesh"> {
     **Constraints:**
     - Elements in `axes` must not have duplicate names.
     - If `device_ids` is specified:
-      - The product of axis sizes must match the number of devices.
-      - All of its elements must be non-negative.
-      - `device_ids` should not be equal to `iota(product(axis_sizes))`.
-      - Sorted `device_ids` must be `iota(product(axis_sizes))`.
+      * The product of axis sizes must match the number of devices.
+      * All of its elements must be non-negative.
+      * `device_ids` should not be equal to `iota(product(axis_sizes))`.
+      * Sorted `device_ids` must be `iota(product(axis_sizes))`.
   }];
   let parameters = (ins
       OptionalArrayRefParameter<"MeshAxisAttr", "mesh axes">:$axes,
@@ -725,6 +725,7 @@ def Sdy_DimMapping : AttrDef<Sdy_Dialect, "DimMapping"> {
     - There is at least one factor index.
     - Factor indices must be in range [0, `$factor_sizes`).
     - If there are multiple factors, none of them can have size 1.
+    - No duplicate factor indices.
    }];
   let parameters = (ins
     OptionalArrayRefParameter<"int64_t", "factors this dimension is mapped to">:$factor_indices
@@ -744,6 +745,10 @@ def Sdy_DimMapping : AttrDef<Sdy_Dialect, "DimMapping"> {
 def Sdy_TensorMapping : AttrDef<Sdy_Dialect, "TensorMapping"> {
   let mnemonic = "tensor_mapping";
   let summary = "Factor mappings for each dimension of a tensor.";
+  let description = [{
+      **Constraints:**
+      - Elements in `dim_mappings` must satisfy the constraints in `DimMappingAttr`.
+  }];
   let parameters = (ins
       OptionalArrayRefParameter<"DimMappingAttr", "dimension mappings">:$dim_mappings
   );
@@ -801,7 +806,6 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
       operands/results).
     - Rank of each `TensorMappingAttr` matches the rank of the corresponding
       tensor type.
-    - No duplicate factor indices in each `TensorMappingAttr`.
     - Elements in `reduction_factors` and `need_replication_factors` must
       be in range [0, `$factor_sizes`].
     - No duplicate factor indices in each of `reduction_factors` or
@@ -884,7 +888,7 @@ def Sdy_ListOfAxisRefLists : ArrayOfAttr<Sdy_Dialect, "ListOfAxisRefLists",
   let summary = "List of axis ref lists";
 }
 
-def Sdy_EmptyAxesPerDim : AttrConstraint<
+def Sdy_EmptyAxesPerDim<
     CPred<"$_self.isa<ListOfAxisRefListsAttr>() && "
           "llvm::all_of($_self.cast<ListOfAxisRefListsAttr>(),"
           "               [](const AxisRefListAttr& al) { return al.size() == 0; })">,

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -66,13 +66,13 @@ def Sdy_Mesh : AttrDef<Sdy_Dialect, "Mesh"> {
 
   Here are some examples of meshes:
 
-    - An empty mesh represents a placeholder mesh that can be replaced during
-      propagation: <[]>
-    - A mesh with an unnamed axis and an explicit device ID, which is typically
-      used to represent maximal sharding: <[], device_ids=[3]>
-    - A mesh with two axes and implicit device IDs iota(6): <["a"=2, "b"=3]>
-    - A mesh with two axes and explicit device IDs specifying the device
-      ordering: <["a"=3, "b"=2], device_ids=[0, 2, 4, 1, 3, 5]>
+  - An empty mesh represents a placeholder mesh that can be replaced during
+    propagation: <[]>
+  - A mesh with an unnamed axis and an explicit device ID, which is typically
+    used to represent maximal sharding: <[], device_ids=[3]>
+  - A mesh with two axes and implicit device IDs iota(6): <["a"=2, "b"=3]>
+  - A mesh with two axes and explicit device IDs specifying the device
+    ordering: <["a"=3, "b"=2], device_ids=[0, 2, 4, 1, 3, 5]>
   }];
   let parameters = (ins
       OptionalArrayRefParameter<"MeshAxisAttr", "mesh axes">:$axes,
@@ -151,17 +151,15 @@ def Sdy_SubAxisInfo : AttrDef<Sdy_Dialect, "SubAxisInfo"> {
     k_i. Therefore, the sub-axis-info attribute holds those two numbers and is
     denoted as follows: `(m)k` for pre-size m and size k.
 
-    Constraints:
-
-    For each sub-axis:
-    - Its `pre-size` is at least 1.
-    - Its `size` is greater than 1.
-    - Its next `pre-size` must divide the size of the full axis, i.e., both its
-      `pre-size` and `size` divide the size of the full axis, and the sub-axis
-      doesn't go beyond the full axis.
-    - The size of the sub-axis isn't equal to the size of the full axis, in which
-      case the full axis should be used instead.
-    - It doesn't overlap with any other sub-axis or the full axis.
+    **Constraints:**
+    - `pre-size` is at least 1.
+    - `size` is greater than 1.
+    - `pre-size` must divide the size of the full axis, i.e., both `pre-size`
+      and `size` divide the size of the full axis, and the sub-axis doesn't go
+      beyond the full axis.
+    - The size of the sub-axis isn't equal to the size of the full axis, in
+      which case the full axis should be used instead.
+    - This sub-axis doesn't overlap with any other sub-axis or the full axis.
   }];
   let parameters = (ins
       AttrOrTypeParameter<"int64_t",
@@ -191,9 +189,8 @@ def Sdy_AxisRef : AttrDef<Sdy_Dialect, "AxisRef"> {
   let mnemonic = "axis_ref";
   let summary = "Reference to either a full axis or a split sub-axis";
   let description = [{
-    Constraints:
-
-    If `sub_axis_info` is present, it must satisfy the constraints of `SubAxisInfoAttr`.
+    **Constraints:**
+    - If `sub_axis_info` is present, it must satisfy the constraints of `SubAxisInfoAttr`.
   }];
   let parameters = (ins
       StringRefParameter<"the name of this axis">:$name,
@@ -368,12 +365,11 @@ def Sdy_DimensionSharding : AttrDef<Sdy_Dialect, "DimensionSharding"> {
     sharding annotations and a lower value denotes a higher priority. The
     highest priority is assumed when the priority is missing in the annotation.
 
-    Constraints:
-
-      - Elements in `axes` must satisfy the constraints listed in `Sdy_AxisRefList`.
-      - If a dimension sharding has a priority:
-        - The priority is greater than or equal to 0.
-        - The dimension has at least one axis if it is closed.
+    **Constraints:**
+    - Elements in `axes` must satisfy the constraints listed in `AxisRefListAttr`.
+    - If a dimension sharding has a priority:
+      * The priority is greater than or equal to 0.
+      * The dimension has at least one axis if it is closed.
   }];
 
   let parameters = (ins
@@ -456,15 +452,14 @@ def Sdy_TensorSharding : AttrDef<Sdy_Dialect, "TensorSharding"> {
     The mesh this sharding is bound to can either be specified by a symbol
     name, referencing a corresponding `MeshOp` symbol, or an inlined `MeshAttr`.
 
-    Constraints:
-
-      - Elements in `replicated_axes` must satisfy the constraints listed in `Sdy_AxisRefList`.
-      - If `type` isn't a `ShapedType`, the sharding must have rank 0 and no replicated axes.
-      - The tensor should have a rank.
-      - The number of dimension shardings is equal to the rank of the tensor.
-      - Dimensions of size 0 aren't sharded.
-      - Replicated axes are ordered w.r.t. `mesh_or_ref` (see `AxisRefAttr::getMeshComparator`).
-      - All dimension shardings are valid (see `Sdy_DimensionSharding`).
+    **Constraints:**
+    - Elements in `replicated_axes` must satisfy the constraints listed in `AxisRefListAttr`.
+    - If `type` isn't a `ShapedType`, the sharding must have rank 0 and no replicated axes.
+    - The tensor should have a rank.
+    - The number of dimension shardings is equal to the rank of the tensor.
+    - Dimensions of size 0 aren't sharded.
+    - Replicated axes are ordered w.r.t. `mesh_or_ref` (see `AxisRefAttr::getMeshComparator`).
+    - All dimension shardings are valid (see `Sdy_DimensionSharding`).
   }];
   let parameters = (ins
       Sdy_MeshOrRef:$mesh_or_ref,
@@ -666,9 +661,8 @@ def Sdy_TensorShardingPerValue : AttrDef<Sdy_Dialect, "TensorShardingPerValue"> 
   let description = [{
     A list of `TensorShardingAttr`s, one for each operand/result of an op.
 
-    Constraints:
-
-      - Elements in `shardings` must satisfy the constraints of `Sdy_TensorSharding`.
+    **Constraints:**
+    - Elements in `shardings` must satisfy the constraints of `TensorShardingAttr`.
   }];
   let parameters = (ins
       OptionalArrayRefParameter<"TensorShardingAttr", "shardings per value">:$shardings
@@ -788,9 +782,9 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
     rule is always preserved/never removed. `is_custom_rule` can only be true
     for `stablehlo.custom_call` ops.
 
-    Constraints:
-
-    - Number of mappings and types match.
+    **Constraints:**
+    - Number of operand/result mappings must match the number of
+      operands/results of the op.
     - There is at least one mapping (can't have a rule for an op with no
       operands/results).
     - Rank of each `TensorMappingAttr` matches the rank of the corresponding
@@ -798,7 +792,7 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
     - No duplicate factor indices in each `TensorMappingAttr`.
     - Per `DimMappingAttr`:
       * There is at least one factor index.
-      * Factor indices must be in range [0, `factorSizes.size()`).
+      * Factor indices must be in range [0, `$factor_sizes`).
       * If there are multiple factors, none of them can have size 1.
   }];
 
@@ -864,8 +858,7 @@ def Sdy_AxisRefList : ArrayOfAttr<Sdy_Dialect, "AxisRefList",
   let assemblyFormat = "`{` (`}`) : ($value^ `` `}`)?";
   let summary = "List of axis refs";
   let description = [{
-    Constraints:
-
+    **Constraints:**
     - There are no duplicate axis-refs.
     - No two adjacent axis-refs are consecutive sub-axes of that same full axis,
       i.e., they can be merged into one sub-axis or the full axis.

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -748,6 +748,7 @@ def Sdy_TensorMapping : AttrDef<Sdy_Dialect, "TensorMapping"> {
   let description = [{
       **Constraints:**
       - Elements in `dim_mappings` must satisfy the constraints in `DimMappingAttr`.
+      - No duplicate factors indices across dimensions.
   }];
   let parameters = (ins
       OptionalArrayRefParameter<"DimMappingAttr", "dimension mappings">:$dim_mappings
@@ -806,11 +807,9 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
       operands/results).
     - Rank of each `TensorMappingAttr` matches the rank of the corresponding
       tensor type.
-    - Elements in `reduction_factors` and `need_replication_factors` must
-      be in range [0, `$factor_sizes`].
-    - No duplicate factor indices in each of `reduction_factors` or
-      `need_replication_factors`, and no duplicate factor indices across both
-      `reduction_factors` and `need_replication_factors`.
+    - For each group of factors (`reduction_factors`, `need_replication_factors`):
+      * Elements must be in range [0, `$factor_sizes`].
+      * No duplicate factor indices within each group and across groups.
   }];
 
   let parameters = (ins

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -157,9 +157,8 @@ def Sdy_SubAxisInfo : AttrDef<Sdy_Dialect, "SubAxisInfo"> {
     - `pre-size` must divide the size of the full axis, i.e., both `pre-size`
       and `size` divide the size of the full axis, and the sub-axis doesn't go
       beyond the full axis.
-    - The size of the sub-axis isn't equal to the size of the full axis, in
-      which case the full axis should be used instead.
-    - This sub-axis doesn't overlap with any other sub-axis or the full axis.
+    - The size of the sub-axis isn't equal to the size of the corresponding full
+      axis, in which case the full axis should be used instead.
   }];
   let parameters = (ins
       AttrOrTypeParameter<"int64_t",

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -148,6 +148,18 @@ def Sdy_SubAxisInfo : AttrDef<Sdy_Dialect, "SubAxisInfo"> {
     axis sizes to its left `m=prod(k_1,...,k_(i-1))` (aka pre-size) and size
     k_i. Therefore, the sub-axis-info attribute holds those two numbers and is
     denoted as follows: `(m)k` for pre-size m and size k.
+
+    Constraints:
+
+    For each sub-axis:
+    - Its `pre-size` is at least 1.
+    - Its `size` is greater than 1.
+    - Its next `pre-size` must divide the size of the full axis, i.e., both its
+      `pre-size` and `size` divide the size of the full axis, and the sub-axis
+      doesn't go beyond the full axis.
+    - The size of the sub-axis isn't equal to the size of the full axis, in which
+      case the full axis should be used instead.
+    - It doesn't overlap with any other sub-axis or the full axis.
   }];
   let parameters = (ins
       "int64_t":$pre_size,
@@ -175,6 +187,19 @@ def Sdy_SubAxisInfo : AttrDef<Sdy_Dialect, "SubAxisInfo"> {
 def Sdy_AxisRef : AttrDef<Sdy_Dialect, "AxisRef"> {
   let mnemonic = "axis_ref";
   let summary = "Reference to either a full axis or a split sub-axis";
+  let description = [{
+    Constraints:
+
+    If `sub_axis_info` is present, it must satisfy the following for each sub-axis:
+    - Its `pre-size` is at least 1.
+    - Its `size` is greater than 1.
+    - Its next `pre-size` must divide the size of the full axis, i.e., both its
+      `pre-size` and `size` divide the size of the full axis, and the sub-axis
+      doesn't go beyond the full axis.
+    - The size of the sub-axis isn't equal to the size of the full axis, in which
+      case the full axis should be used instead.
+    - It doesn't overlap with any other sub-axis or the full axis.
+  }];
   let parameters = (ins
       StringRefParameter<"name">:$name,
       OptionalParameter<"SubAxisInfoAttr">:$sub_axis_info
@@ -335,7 +360,7 @@ def Sdy_AxisRef : AttrDef<Sdy_Dialect, "AxisRef"> {
   }];
 }
 
-def Sdy_AxisRefs : OptionalArrayRefParameter<"AxisRefAttr", "list of axis refs">;
+def Sdy_AxisRefs : OptionalArrayRefParameter<"AxisRefAttr", "List of axis refs. Refer to `Sdy_AxisRefList`.">;
 
 def Sdy_DimensionSharding : AttrDef<Sdy_Dialect, "DimensionSharding"> {
   let mnemonic = "dimension_sharding";
@@ -347,6 +372,10 @@ def Sdy_DimensionSharding : AttrDef<Sdy_Dialect, "DimensionSharding"> {
     will respected during sharding propagation. Priorities originate from user
     sharding annotations and a lower value denotes a higher priority. The
     highest priority is assumed when the priority is missing in the annotation.
+
+    Constraints:
+
+      Elements in `axes` must satisfy the constraints listed in `Sdy_AxisRefList`.
   }];
 
   let parameters = (ins
@@ -427,6 +456,19 @@ def Sdy_TensorSharding : AttrDef<Sdy_Dialect, "TensorSharding"> {
 
     The mesh this sharding is bound to can either be specified by a symbol
     name, referencing a corresponding `MeshOp` symbol, or an inlined `MeshAttr`.
+
+    Constraints:
+
+      - Elements in `replicated_axes` must satisfy the constraints listed in `Sdy_AxisRefList`.
+      - If `type` isn't a `ShapedType`, the sharding must have rank 0 and no replicated axes.
+      - The tensor should have a rank.
+      - The number of dimension shardings is equal to the rank of the tensor.
+      - Dimensions of size 0 aren't sharded.
+      - Replicated axes are ordered w.r.t. `mesh_or_ref` (see `AxisRefAttr::getMeshComparator`).
+      - All dimension shardings and the replicated axes are each a valid axis-ref list (see `Sdy_AxisRefList`).
+      - If a dimension sharding has a priority:
+        - The priority is greater than or equal to 0.
+        - The dimension has at least one axis if it is closed.
   }];
   let parameters = (ins
       Sdy_MeshOrRef:$mesh_or_ref,
@@ -625,6 +667,13 @@ def Sdy_TensorSharding : AttrDef<Sdy_Dialect, "TensorSharding"> {
 def Sdy_TensorShardingPerValue : AttrDef<Sdy_Dialect, "TensorShardingPerValue"> {
   let mnemonic = "sharding_per_value";
   let summary = "Tensor sharding per operand/result of an op";
+  let description = [{
+    A list of `TensorShardingAttr`s, one for each operand/result of an op.
+
+    Constraints:
+
+      - Elements in `shardings` must satisfy the constraints of `Sdy_TensorSharding`.
+  }];
   let parameters = (ins
       OptionalArrayRefParameter<"TensorShardingAttr">:$shardings
   );
@@ -738,6 +787,19 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
     these ops, so a user must tell it how. When it is a custom rule, then the
     rule is always preserved/never removed. `is_custom_rule` can only be true
     for `stablehlo.custom_call` ops.
+
+    Constraints:
+
+    - Number of mappings and types match.
+    - There is at least one mapping (can't have a rule for an op with no
+      operands/results).
+    - Rank of each `TensorMappingAttr` matches the rank of the corresponding
+      tensor type.
+    - No duplicate factor indices in each `TensorMappingAttr`.
+    - Per `DimMappingAttr`:
+      * There is at least one factor index.
+      * Factor indices must be in range [0, `factorSizes.size()`).
+      * If there are multiple factors, none of them can have size 1.
   }];
 
   let parameters = (ins
@@ -792,6 +854,17 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
 def Sdy_AxisRefList : ArrayOfAttr<Sdy_Dialect, "AxisRefList",
                                  "axis_ref_list", "AxisRefAttr"> {
   let assemblyFormat = "`{` (`}`) : ($value^ `` `}`)?";
+  let summary = "List of axis refs";
+  let description = [{
+    Constraints:
+
+    - There are no duplicate axis-refs.
+    - No two adjacent axis-refs are consecutive sub-axes of that same full axis,
+      i.e., they can be merged into one sub-axis or the full axis.
+  }];
+  let parameters = (ins
+      OptionalArrayRefParameter<"AxisRefAttr", "axis refs">:$value
+  );
 }
 
 def Sdy_ListOfAxisRefLists : ArrayOfAttr<Sdy_Dialect, "ListOfAxisRefLists",

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -190,15 +190,7 @@ def Sdy_AxisRef : AttrDef<Sdy_Dialect, "AxisRef"> {
   let description = [{
     Constraints:
 
-    If `sub_axis_info` is present, it must satisfy the following for each sub-axis:
-    - Its `pre-size` is at least 1.
-    - Its `size` is greater than 1.
-    - Its next `pre-size` must divide the size of the full axis, i.e., both its
-      `pre-size` and `size` divide the size of the full axis, and the sub-axis
-      doesn't go beyond the full axis.
-    - The size of the sub-axis isn't equal to the size of the full axis, in which
-      case the full axis should be used instead.
-    - It doesn't overlap with any other sub-axis or the full axis.
+    If `sub_axis_info` is present, it must satisfy the constraints of `SubAxisInfoAttr`.
   }];
   let parameters = (ins
       StringRefParameter<"name">:$name,
@@ -375,7 +367,10 @@ def Sdy_DimensionSharding : AttrDef<Sdy_Dialect, "DimensionSharding"> {
 
     Constraints:
 
-      Elements in `axes` must satisfy the constraints listed in `Sdy_AxisRefList`.
+      - Elements in `axes` must satisfy the constraints listed in `Sdy_AxisRefList`.
+      - If a dimension sharding has a priority:
+        - The priority is greater than or equal to 0.
+        - The dimension has at least one axis if it is closed.
   }];
 
   let parameters = (ins
@@ -465,10 +460,7 @@ def Sdy_TensorSharding : AttrDef<Sdy_Dialect, "TensorSharding"> {
       - The number of dimension shardings is equal to the rank of the tensor.
       - Dimensions of size 0 aren't sharded.
       - Replicated axes are ordered w.r.t. `mesh_or_ref` (see `AxisRefAttr::getMeshComparator`).
-      - All dimension shardings and the replicated axes are each a valid axis-ref list (see `Sdy_AxisRefList`).
-      - If a dimension sharding has a priority:
-        - The priority is greater than or equal to 0.
-        - The dimension has at least one axis if it is closed.
+      - All dimension shardings are valid (see `Sdy_DimensionSharding`).
   }];
   let parameters = (ins
       Sdy_MeshOrRef:$mesh_or_ref,

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -888,7 +888,7 @@ def Sdy_ListOfAxisRefLists : ArrayOfAttr<Sdy_Dialect, "ListOfAxisRefLists",
   let summary = "List of axis ref lists";
 }
 
-def Sdy_EmptyAxesPerDim<
+def Sdy_EmptyAxesPerDim : AttrConstraint<
     CPred<"$_self.isa<ListOfAxisRefListsAttr>() && "
           "llvm::all_of($_self.cast<ListOfAxisRefListsAttr>(),"
           "               [](const AxisRefListAttr& al) { return al.size() == 0; })">,

--- a/shardy/dialect/sdy/ir/attrs.td
+++ b/shardy/dialect/sdy/ir/attrs.td
@@ -64,15 +64,20 @@ def Sdy_Mesh : AttrDef<Sdy_Dialect, "Mesh"> {
     same as iota(product(axes)); in this case, a device ID list shouldn't be
     specified.
 
-  Here are some examples of meshes:
+    Here are some examples of meshes:
 
-  - An empty mesh represents a placeholder mesh that can be replaced during
-    propagation: <[]>
-  - A mesh with an unnamed axis and an explicit device ID, which is typically
-    used to represent maximal sharding: <[], device_ids=[3]>
-  - A mesh with two axes and implicit device IDs iota(6): <["a"=2, "b"=3]>
-  - A mesh with two axes and explicit device IDs specifying the device
-    ordering: <["a"=3, "b"=2], device_ids=[0, 2, 4, 1, 3, 5]>
+    - An empty mesh represents a placeholder mesh that can be replaced during
+      propagation: <[]>
+    - A mesh with an unnamed axis and an explicit device ID, which is typically
+      used to represent maximal sharding: <[], device_ids=[3]>
+    - A mesh with two axes and implicit device IDs iota(6): <["a"=2, "b"=3]>
+    - A mesh with two axes and explicit device IDs specifying the device
+      ordering: <["a"=3, "b"=2], device_ids=[0, 2, 4, 1, 3, 5]>
+
+    **Constraints:**
+    - Elements in `axes` must not have duplicate names.
+    - The product of axis sizes must match the number of devices.
+    - If `device_ids` is specified, all of its elements must be non-negative.
   }];
   let parameters = (ins
       OptionalArrayRefParameter<"MeshAxisAttr", "mesh axes">:$axes,
@@ -189,6 +194,7 @@ def Sdy_AxisRef : AttrDef<Sdy_Dialect, "AxisRef"> {
   let summary = "Reference to either a full axis or a split sub-axis";
   let description = [{
     **Constraints:**
+    - `name` must be present in the bound `MeshAttr`.
     - If `sub_axis_info` is present, it must satisfy the constraints of `SubAxisInfoAttr`.
   }];
   let parameters = (ins
@@ -452,13 +458,13 @@ def Sdy_TensorSharding : AttrDef<Sdy_Dialect, "TensorSharding"> {
     name, referencing a corresponding `MeshOp` symbol, or an inlined `MeshAttr`.
 
     **Constraints:**
+    - Elements in `dim_shardings` must satisfy the constraints listed in `DimensionShardingAttr`.
     - Elements in `replicated_axes` must satisfy the constraints listed in `AxisRefListAttr`.
-    - If `type` isn't a `ShapedType`, the sharding must have rank 0 and no replicated axes.
+    - If the corresponding tensor type isn't a `ShapedType`, the sharding must have rank 0 and no replicated axes.
     - The tensor should have a rank.
     - The number of dimension shardings is equal to the rank of the tensor.
     - Dimensions of size 0 aren't sharded.
     - Replicated axes are ordered w.r.t. `mesh_or_ref` (see `AxisRefAttr::getMeshComparator`).
-    - All dimension shardings are valid (see `Sdy_DimensionSharding`).
   }];
   let parameters = (ins
       Sdy_MeshOrRef:$mesh_or_ref,
@@ -709,9 +715,13 @@ def Sdy_DimMapping : AttrDef<Sdy_Dialect, "DimMapping"> {
   let mnemonic = "dim_mapping";
   let summary = "List of factor indices for a dimension";
   let description = [{
-    All factor indices must be in the range [0, num_factors) and an empty list
-    indicates that this is a null mapping (this is parsed/printed with `*`),
-    i.e. the dimension isn't mapped to any factors.
+    An empty list indicates that this is a null mapping (this is parsed/printed
+    with `*`), i.e. the dimension isn't mapped to any factors.
+
+    **Constraints:**
+    - There is at least one factor index.
+    - Factor indices must be in range [0, `$factor_sizes`).
+    - If there are multiple factors, none of them can have size 1.
    }];
   let parameters = (ins
     OptionalArrayRefParameter<"int64_t", "factors this dimension is mapped to">:$factor_indices
@@ -782,6 +792,8 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
     for `stablehlo.custom_call` ops.
 
     **Constraints:**
+    - Elements in `reduction_factors` and `need_replication_factors` must
+      satisfy the constraints of `DimMappingAttr`.
     - Number of operand/result mappings must match the number of
       operands/results of the op.
     - There is at least one mapping (can't have a rule for an op with no
@@ -789,10 +801,6 @@ def Sdy_OpShardingRule : AttrDef<Sdy_Dialect, "OpShardingRule"> {
     - Rank of each `TensorMappingAttr` matches the rank of the corresponding
       tensor type.
     - No duplicate factor indices in each `TensorMappingAttr`.
-    - Per `DimMappingAttr`:
-      * There is at least one factor index.
-      * Factor indices must be in range [0, `$factor_sizes`).
-      * If there are multiple factors, none of them can have size 1.
   }];
 
   let parameters = (ins
@@ -858,6 +866,7 @@ def Sdy_AxisRefList : ArrayOfAttr<Sdy_Dialect, "AxisRefList",
   let summary = "List of axis refs";
   let description = [{
     **Constraints:**
+    - Elements in `value` must satisfy the constraints of `AxisRefAttr`.
     - There are no duplicate axis-refs.
     - No two adjacent axis-refs are consecutive sub-axes of that same full axis,
       i.e., they can be merged into one sub-axis or the full axis.

--- a/shardy/dialect/sdy/ir/ops.td
+++ b/shardy/dialect/sdy/ir/ops.td
@@ -139,11 +139,10 @@ def Sdy_ManualComputationOp : Sdy_Op<"manual_computation",
     the body on any free axes - those not in the manual_axes list.
 
     **Constraints:**
-    - The in/out shardings of the op values (operands/results) must be valid
-      w.r.t the corresponding global type
-    - The number of global and local tensor inputs/outputs of the op region must match
-    - The manual axes must come before any free axes in each dim sharding
-    - The global and local shapes of the op regions arguments/results must match
+    - Elements in `in_shardings` and `out_shardings` must satisfy the constraints listed in `TensorShardingAttr`.
+    - The number of global and local tensor inputs/outputs of the op region must match.
+    - The manual axes must come before any free axes in each dim sharding.
+    - The global and local shapes of the op regions arguments/results must match.
     - No manual axes are split.
   }];
 
@@ -454,9 +453,8 @@ def Sdy_AllGatherOp : Sdy_Op<"all_gather",
     ```
 
     **Constraints:**
-    - `MeshAttr` of result and operand is the same
-    - All axis names in `gatheringAxes` are present.
-    - Each item in `gatheringAxes` must satisfy the constraints for `Sdy_AxisRefList`.
+    - Both operand and result shardings should be bound to the same `MeshAttr`.
+    - Elements in `gatheringAxes` must satisfy the constraints listed in `AxisRefListAttr`.
   }];
 
   let arguments = (ins

--- a/shardy/dialect/sdy/ir/ops.td
+++ b/shardy/dialect/sdy/ir/ops.td
@@ -453,8 +453,8 @@ def Sdy_AllGatherOp : Sdy_Op<"all_gather",
     ```
 
     **Constraints:**
-    - Both operand and result shardings should be bound to the same `MeshAttr`.
     - Elements in `gatheringAxes` must satisfy the constraints listed in `AxisRefListAttr`.
+    - Both operand and result shardings should be bound to the same `MeshAttr`.
   }];
 
   let arguments = (ins

--- a/shardy/dialect/sdy/ir/ops.td
+++ b/shardy/dialect/sdy/ir/ops.td
@@ -137,6 +137,15 @@ def Sdy_ManualComputationOp : Sdy_Op<"manual_computation",
 
     The body is local wrt the manual_axes. Propagation will occur through
     the body on any free axes - those not in the manual_axes list.
+
+    Constraints:
+
+      For each set of op values (operands/results) and corresponding sharding for each value:
+      - The in/out shardings must valid w.r.t the corresponding global type
+      - The number of global and local tensor inputs/outputs of the op region must match
+      - The manual axes must come before any free axes in each dim sharding
+      - The global shape and local shapes of the op regions arguments/results must match
+      - No manual axes must be split.
   }];
 
   let arguments = (ins
@@ -445,6 +454,10 @@ def Sdy_AllGatherOp : Sdy_Op<"all_gather",
     %2 = sdy.all_gather gathering_axes=[{"b", "c"}, {}, {"d"}\] %1 to_sharding=<@mesh, [{"a"}, {}, {}\]> : tensor<8x8xf32>
     ```
 
+    Constraints:
+    - `MeshAttr` of result and operand is the same
+    - All axis names in `gatheringAxes` are present.
+    - Each item in `gatheringAxes` must satisfy the constraints for `Sdy_AxisRefList`.
   }];
 
   let arguments = (ins

--- a/shardy/dialect/sdy/ir/ops.td
+++ b/shardy/dialect/sdy/ir/ops.td
@@ -143,7 +143,7 @@ def Sdy_ManualComputationOp : Sdy_Op<"manual_computation",
       w.r.t the corresponding global type
     - The number of global and local tensor inputs/outputs of the op region must match
     - The manual axes must come before any free axes in each dim sharding
-    - The global shape and local shapes of the op regions arguments/results must match
+    - The global and local shapes of the op regions arguments/results must match
     - No manual axes are split.
   }];
 

--- a/shardy/dialect/sdy/ir/ops.td
+++ b/shardy/dialect/sdy/ir/ops.td
@@ -138,14 +138,13 @@ def Sdy_ManualComputationOp : Sdy_Op<"manual_computation",
     The body is local wrt the manual_axes. Propagation will occur through
     the body on any free axes - those not in the manual_axes list.
 
-    Constraints:
-
-      For each set of op values (operands/results) and corresponding sharding for each value:
-      - The in/out shardings must valid w.r.t the corresponding global type
-      - The number of global and local tensor inputs/outputs of the op region must match
-      - The manual axes must come before any free axes in each dim sharding
-      - The global shape and local shapes of the op regions arguments/results must match
-      - No manual axes are split.
+    **Constraints:**
+    - The in/out shardings of the op values (operands/results) must be valid
+      w.r.t the corresponding global type
+    - The number of global and local tensor inputs/outputs of the op region must match
+    - The manual axes must come before any free axes in each dim sharding
+    - The global shape and local shapes of the op regions arguments/results must match
+    - No manual axes are split.
   }];
 
   let arguments = (ins
@@ -276,7 +275,6 @@ def Sdy_DataFlowEdgeOp : Sdy_Op<"data_flow_edge",
     An op can have multiple data flow edges that are orthogonal to one another.
 
     For example:
-
 
     ```mlir
       y_0, ..., y_n = while (x_0, ..., x_n)
@@ -455,7 +453,7 @@ def Sdy_AllGatherOp : Sdy_Op<"all_gather",
     %2 = sdy.all_gather gathering_axes=[{"b", "c"}, {}, {"d"}\] %1 to_sharding=<@mesh, [{"a"}, {}, {}\]> : tensor<8x8xf32>
     ```
 
-    Constraints:
+    **Constraints:**
     - `MeshAttr` of result and operand is the same
     - All axis names in `gatheringAxes` are present.
     - Each item in `gatheringAxes` must satisfy the constraints for `Sdy_AxisRefList`.

--- a/shardy/dialect/sdy/ir/ops.td
+++ b/shardy/dialect/sdy/ir/ops.td
@@ -145,7 +145,7 @@ def Sdy_ManualComputationOp : Sdy_Op<"manual_computation",
       - The number of global and local tensor inputs/outputs of the op region must match
       - The manual axes must come before any free axes in each dim sharding
       - The global shape and local shapes of the op regions arguments/results must match
-      - No manual axes must be split.
+      - No manual axes are split.
   }];
 
   let arguments = (ins


### PR DESCRIPTION
Adds constraints based on comments in https://github.com/openxla/shardy/blob/main/shardy/dialect/sdy/ir/verifiers.cc

As always, feedback is appreciated - I'm not completely confident I am adding the correct amount of details to the correct places. I am also not sure I am citing existing objects correctly - I am guessing we may want to use `AxisRefListAttr` instead of `Sdy_AxisRefList`, but since I'm not sure I'm leaving as is for now.

Thanks again for the patience!