### PR TITLE
Use local spawn strategy for faster builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,6 @@
+# Use the "local" spawn strategy to improve build performance
+build --spawn_strategy=local
+
 # Flag to enable remote config
 common --experimental_repo_remote_exec
 


### PR DESCRIPTION
By default, Bazel uses `spawn_strategy=sandbox`, which can be slow, especially for projects with heavy dependencies like LLVM/MLIR.  

To significantly speed up the build, we can use the "local" strategy, which fully utilizes available CPU cores. This change improves build time by 5.9x  

```  
# Default: --spawn_strategy=sandbox  
# CPU utilization: 2-4%  
bazel build //shardy/tools/...  27:54.99 total

# With --spawn_strategy=local  
# CPU utilization: 100%  
bazel build //shardy/tools/...  4:42.87 total 
```  

Both XLA and TensorFlow builds also use spawn_strategy=standalone (old name for local) for better performance

This PR updates `.bazelrc` to set `spawn_strategy=local`, reducing build times by 5.9x.  

Tested on: `m5.24xlarge` (48 cores / 96 threads), Linux.  