### PR TITLE
Add support for custom sharding rules via ShardingRuleOpInterface

### DIFF
--- a/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
+++ b/shardy/dialect/sdy/transforms/propagation/op_sharding_rule_registry.cc
@@ -687,6 +687,11 @@ OpShardingRuleAttr createOpShardingRule(Operation* op,
           }
           return OpShardingRuleBuilder::buildPointwise(customCall);
         }
+        if (auto shardingRuleOp =
+              llvm::dyn_cast<ShardingRuleOpInterface>(
+                customCall.getOperation())) {
+          return shardingRuleOp.getShardingRule();
+        }
         // TODO(b/327191011): output unregistered op stats instead.
         static llvm::once_flag onceFlag;
         emitOpWarningOnce(


### PR DESCRIPTION
Allows custom ops to supply their own sharding rules when not covered by the default registry.