### PR TITLE
Add missing loads for Bazel 8+ support

### DIFF
--- a/shardy/common/BUILD
+++ b/shardy/common/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/shardy/dialect/mpmd/ir/BUILD
+++ b/shardy/dialect/mpmd/ir/BUILD
@@ -1,7 +1,7 @@
 # The MPMD MLIR dialect.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
-# load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "gentbl_filegroup", "td_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/shardy/dialect/mpmd/transforms/BUILD
+++ b/shardy/dialect/mpmd/transforms/BUILD
@@ -1,6 +1,6 @@
 # The MPMD dialect passes and pipelines.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/shardy/dialect/mpmd/transforms/common/BUILD
+++ b/shardy/dialect/mpmd/transforms/common/BUILD
@@ -1,7 +1,7 @@
 # The MPMD common library and passes.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
-# load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/shardy/dialect/mpmd/transforms/export/BUILD
+++ b/shardy/dialect/mpmd/transforms/export/BUILD
@@ -1,7 +1,7 @@
 # The MPMD export passes and pipeline.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
-# load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/shardy/dialect/mpmd/transforms/import/BUILD
+++ b/shardy/dialect/mpmd/transforms/import/BUILD
@@ -1,7 +1,7 @@
 # The MPMD import passes and pipeline.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
-# load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/shardy/dialect/mpmd/transforms/optimize/BUILD
+++ b/shardy/dialect/mpmd/transforms/optimize/BUILD
@@ -1,7 +1,7 @@
 # The MPMD optimize passes and pipeline.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
-# load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/shardy/dialect/mpmd/transforms/sharding_propagation/BUILD
+++ b/shardy/dialect/mpmd/transforms/sharding_propagation/BUILD
@@ -1,6 +1,6 @@
 # The MPMD sharding propagation passes and pipeline.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/shardy/dialect/sdy/ir/BUILD
+++ b/shardy/dialect/sdy/ir/BUILD
@@ -1,7 +1,7 @@
 # The SDY MLIR dialect.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
-# load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "gentbl_filegroup", "td_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/shardy/dialect/sdy/transforms/BUILD
+++ b/shardy/dialect/sdy/transforms/BUILD
@@ -1,6 +1,6 @@
 # The SDY dialect passes and pipelines.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/shardy/dialect/sdy/transforms/common/BUILD
+++ b/shardy/dialect/sdy/transforms/common/BUILD
@@ -1,7 +1,7 @@
 # The SDY transformations common library.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
-# load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/shardy/dialect/sdy/transforms/export/BUILD
+++ b/shardy/dialect/sdy/transforms/export/BUILD
@@ -1,6 +1,6 @@
 # The SDY export passes and pipeline.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/shardy/dialect/sdy/transforms/import/BUILD
+++ b/shardy/dialect/sdy/transforms/import/BUILD
@@ -1,6 +1,6 @@
 # The SDY import passes and pipeline.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/shardy/dialect/sdy/transforms/propagation/BUILD
+++ b/shardy/dialect/sdy/transforms/propagation/BUILD
@@ -1,7 +1,7 @@
 # The SDY sharding propagation system.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
-# load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/shardy/dialect/sdy/transforms/propagation/debugging/BUILD
+++ b/shardy/dialect/sdy/transforms/propagation/debugging/BUILD
@@ -1,6 +1,6 @@
 # Systems to debug SDY propagation.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/shardy/integrations/c/BUILD
+++ b/shardy/integrations/c/BUILD
@@ -1,6 +1,6 @@
 # SDY C APIs.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/shardy/integrations/c/mpmd/BUILD
+++ b/shardy/integrations/c/mpmd/BUILD
@@ -1,6 +1,6 @@
 # MPMD C APIs.
 
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/shardy/integrations/python/jax/mpmd/jaxlib/BUILD
+++ b/shardy/integrations/python/jax/mpmd/jaxlib/BUILD
@@ -1,4 +1,4 @@
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/shardy/tools/BUILD
+++ b/shardy/tools/BUILD
@@ -1,6 +1,6 @@
 # Shardy tools.
 
-# load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/third_party/py/py_extension.bzl
+++ b/third_party/py/py_extension.bzl
@@ -13,8 +13,8 @@
 # limitations under the License.
 """Supports writing Python modules in C++."""
 
-# load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
-# load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 # buildifier: disable=unused-variable
 def py_extension(


### PR DESCRIPTION
This PR doesn't upgrade Bazel version nor adds support to bzlmod.
It just adds back missing loads that are required for consuming part of shardy packages through Bazel 8+.

We [zml](https://github.com/zml/zml), consume parts the shardy targets through Bazel 9 and would benefit from those patches being upstreamed.

Hopefully this is harmless.