### PR TITLE
docs: Add docstring to mlirRegisterAllSdyPassesAndPipelines

### DIFF
--- a/shardy/integrations/c/passes.cc
+++ b/shardy/integrations/c/passes.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "shardy/dialect/sdy/transforms/passes.h"
 
+/// @brief Registers all SDY passes and pipelines.
 void mlirRegisterAllSdyPassesAndPipelines() {
   mlir::sdy::registerAllSdyPassesAndPipelines();
 }


### PR DESCRIPTION
### 问题背景
公共函数 `mlirRegisterAllSdyPassesAndPipelines` 缺少文档注释，这可能导致代码可读性和维护性降低，不利于开发者理解和使用该函数。

### 修改内容
- **修改了什么**：为 `mlirRegisterAllSdyPassesAndPipelines` 函数添加了 Doxygen 风格的文档注释（`/// @brief`）。
- **为什么这样改**：遵循仓库的代码风格和最佳实践，提高函数的可读性和文档完整性，使维护者和新贡献者能快速理解函数用途。
- **对代码质量的提升**：增强代码自文档化能力，减少后续维护成本，不影响功能、性能或安全性。

### 验证方式
- **现有测试**：通过仓库的现有测试套件，确保修改未引入任何功能变化或破坏。
- **新测试**：无需添加新测试，因为修改仅限于文档注释，不改变代码逻辑。
- **手动验证**：确认注释格式和内容准确反映函数功能，并符合仓库的文档风格。

### 其他信息
- **Breaking changes**：无，此修改仅为文档改进，不影响公共 API 或行为。
- **文档更新**：无需更新外部文档，因为修改是代码内部文档注释。
- **已知限制**：无。