### PR TITLE
reshard: fix reverse-iterator direction in getGatheringAxes

### DIFF
--- a/shardy/dialect/sdy/transforms/export/reshard_to_collectives.cc
+++ b/shardy/dialect/sdy/transforms/export/reshard_to_collectives.cc
@@ -348,7 +348,7 @@ class CollectiveInserter {
     while (axisRevIt != inAxes.rend() &&
            !outAxisToDimAndIndex.contains(*axisRevIt)) {
       inAxisSet.erase(*axisRevIt);
-      --axisRevIt;
+      ++axisRevIt;
     }
     auto inAxisIt = axisRevIt.base();
     popBackFromCurrentAxes(currentAxes, inAxes, inAxisIt);


### PR DESCRIPTION
### Problem
`CollectiveInserter::getGatheringAxes` (`shardy/dialect/sdy/transforms/export/reshard_to_collectives.cc`) over-gathers a dimension during reshard lowering: it can return the entire axis list (including axes still present in the output sharding) instead of only the trailing axes absent from the output.

### Root cause
The suffix scan starts at `inAxes.rbegin()` and does `--axisRevIt`, which advances the `std::list` reverse_iterator toward the back (off the end) rather than toward the front:
```cpp
auto axisRevIt = inAxes.rbegin();
while (axisRevIt != inAxes.rend() &&
       !outAxisToDimAndIndex.contains(*axisRevIt)) {
  inAxisSet.erase(*axisRevIt);
  --axisRevIt;   // wrong direction
}
```
For the function's own documented example (`inAxesPerDim = [[], ["x","y","z","w"]]`, `outAxesPerDim = [["y"], []]`, expected `["z","w"]`), `--` stops after one step and `axisRevIt.base()` lands at the front, so the tail loop gathers `["x","y","z","w"]` — wrongly gathering `"y"`, which the output still needs — and leaves `currentAxes` / `inAxisSet` inconsistent.

The sibling reverse scan in `getAllToAllInfo` (line ~1134) and `popBackFromCurrentAxes` (line 118) both use `++`.

### Fix
Advance with `++axisRevIt`.

### Verification
Static reasoning + consistency with the sibling scans; reproduces the documented example. No bazel build available on my machine — happy to add a lit test for a reshard that lowers to an all-gather.
