### PR TITLE
Reject negative index in getValueFromEdgeValueRef

### DIFF
--- a/shardy/dialect/sdy/ir/verifiers.cc
+++ b/shardy/dialect/sdy/ir/verifiers.cc
@@ -1116,10 +1116,12 @@ LogicalResult verifyEdgeValueRef(EdgeValueRefAttr edgeValueRef, Operation* op) {
 // Returns nullptr if the index is out of bounds.
 Value getValueFromEdgeValueRef(EdgeValueRefAttr edgeValueRef, Operation* op) {
   if (edgeValueRef.getType() == EdgeNodeType::RESULT &&
+      edgeValueRef.getIndex() >= 0 &&
       edgeValueRef.getIndex() < op->getNumResults()) {
     return op->getResult(edgeValueRef.getIndex());
   }
   if (edgeValueRef.getType() == EdgeNodeType::OPERAND &&
+      edgeValueRef.getIndex() >= 0 &&
       edgeValueRef.getIndex() < op->getNumOperands()) {
     return op->getOperand(edgeValueRef.getIndex());
   }


### PR DESCRIPTION
### Problem
`getValueFromEdgeValueRef` is documented to *"return nullptr if the index is out of bounds"*, but its bounds check omits the lower bound, so a negative index is not treated as out of bounds and is dereferenced instead.

### Details
```cpp
// Returns nullptr if the index is out of bounds.
Value getValueFromEdgeValueRef(EdgeValueRefAttr edgeValueRef, Operation* op) {
  if (edgeValueRef.getType() == EdgeNodeType::RESULT &&
      edgeValueRef.getIndex() < op->getNumResults()) {          // no `>= 0`
    return op->getResult(edgeValueRef.getIndex());
  }
  ...
}
```
`getIndex()` is `int64_t`, and `getNumResults()`/`getNumOperands()` return `unsigned` (promoted to `int64_t` in the comparison), so the check is signed and a negative index (e.g. `-1`) passes it. `op->getResult(unsigned)` / `op->getOperand(unsigned)` then convert the negative value to a large unsigned index → out-of-bounds access, instead of the `nullptr` the function documents.

The sibling verifier `verifyEdgeValueRef` already guards `index < 0 || index >= ...`, so a negative index is an anticipated case; this helper — which runs first, via `getShardingsReferenceByPropagationEdge` in `verifyPropagationEdgesShardingAttr`, before `verifyEdgeValueRef` is reached — is simply missing the lower-bound half of the check.

### Fix
Add the `>= 0` check to both branches, matching `verifyEdgeValueRef` and the function's documented contract. A negative index now returns `nullptr`, and `verifyEdgeValueRef` subsequently emits the clean `expected a value ref to have a … index in range [0, N)` diagnostic instead of an out-of-bounds access.

### Testing
Static reasoning (no local build here). `edge_sharding_verification.mlir` already covers the positive out-of-range diagnostics (`operand-3`, `result-1`); happy to add a negative-index case if the textual `operand-N` format round-trips a negative index.
