### PR TITLE
Diagnose non-ranked region types in ManualComputationOp instead of crashing

### DIFF
--- a/shardy/dialect/sdy/ir/test/manual_computation_verification.mlir
+++ b/shardy/dialect/sdy/ir/test/manual_computation_verification.mlir
@@ -294,3 +294,19 @@ func.func @ranked_sharding_on_token(%arg0: !stablehlo.token) -> !stablehlo.token
   } : (!stablehlo.token) -> !stablehlo.token
   return %0 : !stablehlo.token
 }
+
+// -----
+
+sdy.mesh @mesh = <["a"=2]>
+
+// The region argument type is a token (non-ranked) while the operand is a
+// ranked tensor. This must be diagnosed rather than crash on an unchecked cast
+// of the local type to RankedTensorType.
+func.func @man_comp_operand_non_ranked_local_type(%arg0: tensor<16x32xf32>) -> tensor<16x32xf32> {
+  // expected-error @+1 {{op operand shape, corresponding sharding, and region operand shape at index 0 must match. Expected local shape 'tensor<16x32xf32>', actual local shape '!stablehlo.token'}}
+  %0 = sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{}, {}]>] out_shardings=[<@mesh, [{}, {}]>] manual_axes={} (%arg1: !stablehlo.token) {
+    %1 = stablehlo.constant dense<0.000000e+00> : tensor<16x32xf32>
+    sdy.return %1 : tensor<16x32xf32>
+  } : (tensor<16x32xf32>) -> tensor<16x32xf32>
+  func.return %0: tensor<16x32xf32>
+}

--- a/shardy/dialect/sdy/ir/verifiers.cc
+++ b/shardy/dialect/sdy/ir/verifiers.cc
@@ -999,13 +999,13 @@ LogicalResult verifyManualComputationValue(
     //    arguments/results match.
     auto expectedLocalRankedType =
         RankedTensorType::get(newDimSizes, globalShapedType.getElementType());
-    auto localRankedType = cast<RankedTensorType>(localType);
+    auto localRankedType = dyn_cast<RankedTensorType>(localType);
     if (expectedLocalRankedType != localRankedType) {
       return op->emitOpError(valueKindStr)
              << " shape, corresponding sharding, and region " << valueKindStr
              << " shape at index " << valueIndex
              << " must match. Expected local shape " << expectedLocalRankedType
-             << ", actual local shape " << localRankedType;
+             << ", actual local shape " << localType;
     }
   }
 


### PR DESCRIPTION
### Problem
`ManualComputationOp::verifySymbolUses` crashes (assertion failure in debug, UB in release) on parseable IR when a region argument (or terminator operand) has a non-ranked type — e.g. a `!stablehlo.token` or an unranked tensor — while the corresponding operand/result is a ranked tensor.

### Root cause
In `verifyManualComputationValue` (`verifiers.cc`), the **global** type is guarded before use:
```cpp
auto globalShapedType = dyn_cast<ShapedType>(globalType);
if (!globalShapedType) {
  // Skipping verification for non-shaped types. This could for example be
  // a token type.
  continue;
}
```
but the **local** (region) type a few lines later is force-cast:
```cpp
auto localRankedType = cast<RankedTensorType>(localType);   // crashes if localType is non-ranked
if (expectedLocalRankedType != localRankedType) {
  return op->emitOpError(valueKindStr) << ... << ", actual local shape " << localRankedType;
}
```
`ManualComputationOp` declares `Variadic<AnyType>` operands/results and an unconstrained `SizedRegion<1>` body, so the region argument types are entirely user-controlled and unrelated to the operand types (this is why the op has an explicit "global and local shapes ... must match" check to diagnose mismatches). When the local type is not a `RankedTensorType`, `cast<>` aborts instead of emitting that diagnostic.

This is reachable directly: the sharding check (`verifyTensorShardingPerValueAttr`) only inspects the global types, the operand/region counts match, and a ranked global builds `expectedLocalRankedType` — then the unguarded cast on the token local aborts. `NamedComputationOp` handles the analogous case with a plain `!=` type comparison (no cast), confirming a type-kind mismatch is expected input to be diagnosed, not crashed on.

### Fix
Use `dyn_cast` and report the original `localType` (always non-null) in the diagnostic:
```cpp
auto localRankedType = dyn_cast<RankedTensorType>(localType);
if (expectedLocalRankedType != localRankedType) {
  return op->emitOpError(valueKindStr) << ... << ", actual local shape " << localType;
}
```
For a non-ranked local, `localRankedType` is null, so `expectedLocalRankedType != localRankedType` is true and the existing "shape ... must match" diagnostic is emitted. For a ranked local the behavior is unchanged (`localType == localRankedType`), so existing tests produce byte-identical messages.

### Test
`man_comp_operand_non_ranked_local_type` in `manual_computation_verification.mlir`: a `manual_computation` whose operand is `tensor<16x32xf32>` but whose region argument is `!stablehlo.token` now reports the shape-mismatch error instead of crashing.

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
