### PR TITLE
Fix out-of-bounds read for unscattered dims in multi-dim reduce-scatter lowering

### DIFF
--- a/shardy/dialect/sdy/transforms/export/convert_global_to_local.cc
+++ b/shardy/dialect/sdy/transforms/export/convert_global_to_local.cc
@@ -1183,7 +1183,10 @@ class ReduceScatterOpPattern : public OpConversionPattern<ReduceScatterOp> {
     for (int64_t i = 0; i < rank; ++i) {
       auto* it = llvm::find(scatteredDims, i);
       if (it == scatteredDims.end()) {
+        // This dimension is not scattered; keep its original size and do not
+        // emit a factor sub-dimension for it.
         splitShape.push_back(inputShape[i]);
+        continue;
       }
       int64_t factor =
           scatteredFactors[std::distance(scatteredDims.begin(), it)];

--- a/shardy/dialect/sdy/transforms/export/test/convert_global_to_local/sdy_reduce_scatter_partial_dims.mlir
+++ b/shardy/dialect/sdy/transforms/export/test/convert_global_to_local/sdy_reduce_scatter_partial_dims.mlir
@@ -1,0 +1,18 @@
+// RUN: sdy_opt %s -sdy-convert-global-to-local='combine-multi-dimension-reduce-scatter=true' | FileCheck %s
+
+sdy.mesh @mesh_2_4_2 = <["x"=2, "y"=4, "z"=2]>
+
+// Regression test: a reduce-scatter that scatters two dimensions of a rank-3
+// tensor while leaving the third unscattered. The combining lowering previously
+// fell through the "not scattered" branch (missing `continue`) and read past the
+// end of the scattering-factors vector for the unscattered dimension. Verify the
+// pass lowers it to a single reduce-scatter without crashing.
+// CHECK-LABEL: func @reduce_scatter_partial_multi_dim
+func.func @reduce_scatter_partial_multi_dim(
+    %arg0: tensor<16x8x4xf32> {sdy.sharding = #sdy.sharding<@mesh_2_4_2, [{"y":(1)2}, {}, {}]>})
+    -> (tensor<16x8x4xf32> {sdy.sharding = #sdy.sharding<@mesh_2_4_2, [{"y", "z"}, {"x"}, {}]>}) {
+  // CHECK: stablehlo.reduce_scatter
+  %0 = sdy.reduce_scatter [{"y":(2)2, "z"}, {"x"}, {}] %arg0
+      out_sharding=<@mesh_2_4_2, [{"y", "z"}, {"x"}, {}]> : tensor<16x8x4xf32>
+  return %0 : tensor<16x8x4xf32>
+}


### PR DESCRIPTION
### Problem
`-sdy-convert-global-to-local='combine-multi-dimension-reduce-scatter=true'` reads past the end of a `SmallVector` (and can divide by a garbage factor) when lowering a `reduce_scatter` that scatters two or more dimensions but leaves at least one dimension unscattered.

### Root cause
In `ReduceScatterOpPattern::rewriteReduceScatterCombiningMultipleDims` (`convert_global_to_local.cc`), the loop that splits each scattered dimension into `(factor, quotient)` handles a non-scattered dimension but forgets to `continue`:
```cpp
auto* it = llvm::find(scatteredDims, i);
if (it == scatteredDims.end()) {
  splitShape.push_back(inputShape[i]);
}                                              // <-- missing continue
int64_t factor =
    scatteredFactors[std::distance(scatteredDims.begin(), it)];
...
if (inputShape[i] == ShapedType::kDynamic || inputShape[i] % factor != 0) { ... }
```
When dimension `i` is not scattered, `it == scatteredDims.end()`, so `std::distance(begin, end) == scatteredDims.size()`, and `scatteredFactors[scatteredDims.size()]` is one past the end (`scatteredFactors.size() == scatteredDims.size()`). Execution then pushes a bogus factor sub-dimension into `splitShape`, records it in `factorDimIndices` (corrupting the subsequent transpose permutation), and computes `inputShape[i] % factor` on the garbage value (a SIGFPE if it happens to be 0). Under an assertions-enabled build (standard for MLIR) the `SmallVector::operator[]` bounds assert aborts.

The sibling all-to-all combining routine has the `continue`; this is an omission in the reduce-scatter adaptation. The only existing multi-dimension test happens to scatter *all* dimensions, so the unscattered-dimension path is untested.

### Fix
Add the missing `continue` so a non-scattered dimension keeps its original size and does not emit a factor sub-dimension. This is a no-op for the all-dimensions-scattered case.

### Test
`sdy_reduce_scatter_partial_dims.mlir`: a rank-3 `reduce_scatter` that scatters dimensions 0 and 1 but leaves dimension 2 unscattered now lowers to a single `stablehlo.reduce_scatter` instead of reading out of bounds.

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
