### PR TITLE
Parse sharding rule factor sizes as int64_t

### DIFF
--- a/shardy/dialect/sdy/ir/parsers.cc
+++ b/shardy/dialect/sdy/ir/parsers.cc
@@ -353,7 +353,7 @@ ParseResult parseFactorSizes(AsmParser& parser,
       return failure();
     }
 
-    int factorSize;
+    int64_t factorSize;
     if (parser.parseInteger(factorSize)) {
       return failure();
     }

--- a/shardy/dialect/sdy/ir/test/sharding_rule_parse_print.mlir
+++ b/shardy/dialect/sdy/ir/test/sharding_rule_parse_print.mlir
@@ -47,6 +47,13 @@ func.func @custom_call_custom_rule(%arg0: tensor<16x32xf32>) -> tensor<16x32xf32
   func.return %0: tensor<16x32xf32>
 }
 
+// CHECK-LABEL: func @custom_call_large_factor_size
+func.func @custom_call_large_factor_size(%arg0: tensor<8589934592xf32>) -> tensor<8589934592xf32> {
+  // CHECK: {sdy.sharding_rule = #sdy.op_sharding_rule<([i])->([i]) {i=8589934592}, custom>}
+  %0 = stablehlo.custom_call @foo(%arg0) {sdy.sharding_rule = #sdy.op_sharding_rule<([i])->([i]) {i=8589934592}, custom>} : (tensor<8589934592xf32>) -> tensor<8589934592xf32>
+  func.return %0: tensor<8589934592xf32>
+}
+
 // CHECK-LABEL: func @special_factors
 func.func @special_factors(%arg0: tensor<2x3x5x7xf32>) -> tensor<2x11x7xf32> {
   // CHECK: {sdy.sharding_rule = #sdy.op_sharding_rule<([i, j, k, l])->([i, k, l]) {i=2, j=3, k=5, l=7} reduction={j} need_replication={i, l} permutation={k}, custom>}


### PR DESCRIPTION
Shardy fails to parse sharding rules when a global shape data axis has more than `INT32_MAX` elements.

Parse factor sizes as `int64_t` and add a parse/print test covering a large factor size.