### PR TITLE
Guard empty sharding group in findCommonSharding

### DIFF
--- a/shardy/dialect/sdy/transforms/propagation/sharding_group_map.cc
+++ b/shardy/dialect/sdy/transforms/propagation/sharding_group_map.cc
@@ -66,6 +66,9 @@ struct CommonSharding {
 // If they do, the returned sharding is the sharding of the first value in the
 // group.
 CommonSharding findCommonSharding(int64_t groupId, ValueRange groupMembers) {
+  if (groupMembers.empty()) {
+    return {nullptr, false};
+  }
   if (groupMembers.size() == 1) {
     return {getSharding(groupMembers.front()), false};
   }

--- a/shardy/dialect/sdy/transforms/propagation/test/sharding_group_propagation.mlir
+++ b/shardy/dialect/sdy/transforms/propagation/test/sharding_group_propagation.mlir
@@ -152,6 +152,24 @@ func.func @set_existing_shardings_for_sharding_group_members(
 
 // -----
 
+sdy.mesh @mesh = <["a"=2]>
+
+// A sharding group with a non-contiguous id (group 1 with no group 0) leaves an
+// empty slot in the group map that findCommonSharding previously dereferenced
+// via front(). Propagation must complete without crashing.
+// CHECK-LABEL: func @non_contiguous_sharding_group_id
+func.func @non_contiguous_sharding_group_id(
+    %arg0: tensor<8xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"a"}]>},
+    %arg1: tensor<8xf32>) -> tensor<8xf32> {
+  %0 = stablehlo.add %arg0, %arg0 : tensor<8xf32>
+  %1 = stablehlo.add %arg1, %arg1 : tensor<8xf32>
+  sdy.sharding_group %0 group_id=1 : tensor<8xf32>
+  sdy.sharding_group %1 group_id=1 : tensor<8xf32>
+  return %1 : tensor<8xf32>
+}
+
+// -----
+
 sdy.mesh @mesh = <["a"=2, "b"=2]>
 
 // Emit warning as well for sharding groups which have incompatible shardings


### PR DESCRIPTION
### Problem
Running a propagation pass standalone on a module with a non-contiguous `sdy.sharding_group` id crashes — `findCommonSharding` calls `groupMembers.front()` on an empty `ValueRange`. For example, `sdy_opt -sdy-basic-propagate` on a group whose id starts at 1 (no group 0):
```mlir
sdy.mesh @mesh = <["x"=2]>
func.func @f(%a: tensor<8xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"x"}]>},
             %b: tensor<8xf32>) -> tensor<8xf32> {
  sdy.sharding_group %a group_id=1 : tensor<8xf32>
  sdy.sharding_group %b group_id=1 : tensor<8xf32>
  return %b : tensor<8xf32>
}
```

### Root cause
`ShardingGroupMap` sizes its `shardingGroupToValues` vector by group-id *value* (`resize(max(getGroupId() + 1, size))`), so a non-contiguous id leaves empty gap slots. `syncGroupMemberShardings` then enumerates every slot — including the gaps — and calls `findCommonSharding(groupId, {})`. `findCommonSharding` only special-cases the size-1 case, so an empty range falls through to `groupMembers.front()`, which is undefined behavior.

`group_id` is a plain `I64Attr` with no verifier constraining it to a contiguous `0..N` range, so a group starting at id 1 is valid input. The full `-sdy-propagation-pipeline` canonicalizes ids via `ShardingGroupImportPass` first, but the propagation passes are independently registered and run directly on `sharding_group` ops (as in the propagation tests).

### Fix
Return an empty result for an empty group; the caller already skips groups with no common sharding (`if (!sharding) continue;`).

### Test
`non_contiguous_sharding_group_id` in `sharding_group_propagation.mlir`: a group with id 1 and no id 0 now propagates without crashing.

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
